### PR TITLE
(bugfix): fix compose up when removed uv.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ up: volumes
 
 dev: volumes
 	@echo "Starting docker-compose..."
-	@docker compose up --build --remove-orphans
+	@DEV=1 docker compose up --build --remove-orphans
 
 down:
 	@echo "Stopping docker-compose..."

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,18 +9,17 @@ ENV     UV_CACHE_DIR=${HOME}/.local
 RUN     apk add --no-cache curl ca-certificates build-base
 RUN     curl -LsSf https://astral.sh/uv/install.sh | sh
 
-ENV     PATH=${UV_CACHE_DIR}/bin:$PATH
-RUN     uv python install 3.10
-
-# Build UV inside of /var/backend/src (because relative path)
+# Copy src file content here for building uv
 COPY    src .
 
-# Lock the deps if not found.
-RUN     if [ ! -f uv.lock ]; then uv lock; fi
-
-# Install the deps from lock.
-RUN     rm -f .venv
-RUN     uv sync --compile-bytecode --frozen
+# Install python 3.10, lock uv if not found, and sync uv.
+RUN     PATH=${UV_CACHE_DIR}/bin:$PATH; \
+uv python install 3.10; \
+if [ ! -f uv.lock ]; then \
+    uv lock; \
+fi; \
+rm -f .venv; \
+uv sync --compile-bytecode --frozen
 
 # Strip uv backend binary of unused symbols
 RUN     find ${UV_CACHE_DIR}/bin -type f -exec strip --strip-unneeded {} \;

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,27 +1,38 @@
-# Stage 1 build uv as optimized bytecode.
+## [Stage 1]: Build uv as optimized bytecode. ##
 FROM    alpine:3.22.1 AS build
 WORKDIR /var/backend/src
 
 ENV     HOME=/home/alpine
 ENV     UV_CACHE_DIR=${HOME}/.local
-ENV     PATH=${UV_CACHE_DIR}/bin:$PATH
 
 # Setup dependencies, and user
 RUN     apk add --no-cache curl ca-certificates build-base
 RUN     curl -LsSf https://astral.sh/uv/install.sh | sh
 
+ENV     PATH=${UV_CACHE_DIR}/bin:$PATH
 RUN     uv python install 3.10
 
 # Build UV inside of /var/backend/src (because relative path)
 COPY    src .
-RUN     rm -f .venv
-RUN     uv sync --compile-bytecode --locked
 
-# Stage 2 strip unused dependencies to very barebone uvicorn.
+# Lock the deps if not found.
+RUN     if [ ! -f uv.lock ]; then uv lock; fi
+
+# Install the deps from lock.
+RUN     rm -f .venv
+RUN     uv sync --compile-bytecode --frozen
+
+# Strip uv backend binary of unused symbols
+RUN     find ${UV_CACHE_DIR}/bin -type f -exec strip --strip-unneeded {} \;
+RUN     find /var/backend/src/.venv -type f -exec strip --strip-unneeded {} \;
+
+## [Stage 2]: Strip unused dependencies to very barebone uvicorn. ##
 FROM    alpine:3.22.1 AS runtime
 WORKDIR /var/backend/src
 
-ENV     UV_CACHE_DIR=/home/alpine/.local
+# Copy over binaries
+ENV     HOME=/home/alpine
+ENV     UV_CACHE_DIR=${HOME}/.local
 ENV     PATH=${UV_CACHE_DIR}/bin:$PATH
 
 RUN     adduser -D alpine
@@ -29,6 +40,6 @@ RUN     adduser -D alpine
 COPY    --from=build --chown=alpine:alpine /var/backend/src/.venv /var/backend/venv/
 COPY    --from=build --chown=alpine:alpine ${UV_CACHE_DIR} ${UV_CACHE_DIR}
 
-USER    alpine
+COPY    --from=build /var/backend/src/uv.lock /var/backend/venv/uv.lock
 
-ENTRYPOINT  ["/var/backend/tools/entry.sh"]
+ENTRYPOINT  ["sh", "/var/backend/tools/setup.sh"]

--- a/backend/src/routes/healthcheck.py
+++ b/backend/src/routes/healthcheck.py
@@ -4,4 +4,4 @@ healthcheck_route = APIRouter(prefix = '/healthcheck')
 
 @healthcheck_route.get("/ping")
 async def ping_healthcheck():
-    return 'abc'
+    return 'pong'

--- a/backend/src/uv.lock
+++ b/backend/src/uv.lock
@@ -657,16 +657,16 @@ wheels = [
 
 [[package]]
 name = "rich-toolkit"
-version = "0.15.0"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/36/cdb3d51371ad0cccbf1541506304783bd72d55790709b8eb68c0d401a13a/rich_toolkit-0.15.0.tar.gz", hash = "sha256:3f5730e9f2d36d0bfe01cf723948b7ecf4cc355d2b71e2c00e094f7963128c09", size = 115118, upload-time = "2025-08-11T10:55:37.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/33/1a18839aaa8feef7983590c05c22c9c09d245ada6017d118325bbfcc7651/rich_toolkit-0.15.1.tar.gz", hash = "sha256:6f9630eb29f3843d19d48c3bd5706a086d36d62016687f9d0efa027ddc2dd08a", size = 115322, upload-time = "2025-09-04T09:28:11.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/e4/b0794eefb3cf78566b15e5bf576492c1d4a92ce5f6da55675bc11e9ef5d8/rich_toolkit-0.15.0-py3-none-any.whl", hash = "sha256:ddb91008283d4a7989fd8ff0324a48773a7a2276229c6a3070755645538ef1bb", size = 29062, upload-time = "2025-08-11T10:55:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/49/42821d55ead7b5a87c8d121edf323cb393d8579f63e933002ade900b784f/rich_toolkit-0.15.1-py3-none-any.whl", hash = "sha256:36a0b1d9a135d26776e4b78f1d5c2655da6e0ef432380b5c6b523c8d8ab97478", size = 29412, upload-time = "2025-09-04T09:28:10.587Z" },
 ]
 
 [[package]]
@@ -765,15 +765,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.35.2"
+version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/79/0ecb942f3f1ad26c40c27f81ff82392d85c01d26a45e3c72c2b37807e680/sentry_sdk-2.35.2.tar.gz", hash = "sha256:e9e8f3c795044beb59f2c8f4c6b9b0f9779e5e604099882df05eec525e782cc6", size = 343377, upload-time = "2025-09-01T11:00:58.633Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ac/52fcbba981793d3c90807b79cf6fa130cd25a54d152e653da3ed6d5defef/sentry_sdk-2.36.0.tar.gz", hash = "sha256:af9260e8155e41e8217615a453828e98aa40740865ac4b16b1ccb6a63b4b2e31", size = 343655, upload-time = "2025-09-04T07:56:37.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/91/a43308dc82a0e32d80cd0dfdcfca401ecbd0f431ab45f24e48bb97b7800d/sentry_sdk-2.35.2-py2.py3-none-any.whl", hash = "sha256:38c98e3cbb620dd3dd80a8d6e39c753d453dd41f8a9df581b0584c19a52bc926", size = 363975, upload-time = "2025-09-01T11:00:56.574Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/41ea723cb40f036d699cd954e2894fe7a044b0fd9a0e6bd881b1c9dda14e/sentry_sdk-2.36.0-py2.py3-none-any.whl", hash = "sha256:0f95586a141068d215376e5bf8ebd279e126f7f42805e9570190ef82a7e232b3", size = 364905, upload-time = "2025-09-04T07:56:36.159Z" },
 ]
 
 [[package]]

--- a/backend/tools/entry.sh
+++ b/backend/tools/entry.sh
@@ -2,13 +2,12 @@
 
 set -euo pipefail
 
-# Symlink image built venv
-if [ ! -e .venv ]; then
-    ln -s /var/backend/venv .venv
-fi
-
 # Run uvicorn and detach process
-uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload &
+if [ -n "$DEV" ]; then
+  uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload &
+else
+  uv run uvicorn main:app --host 0.0.0.0 --port 8000 &
+fi
 
 # Passthrough hault signals to uvicorn
 child=$!

--- a/backend/tools/setup.sh
+++ b/backend/tools/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+# Symlink image build venv
+if [ ! -e .venv ]; then
+  ln -s /var/backend/venv .venv
+fi
+
+# Move lockfile into src
+if [ ! -e uv.lock ]; then
+  mv /var/backend/venv/uv.lock uv.lock
+fi
+
+# Execute entry as user
+exec su -m alpine -c "sh /var/backend/tools/entry.sh $@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - "8000:8000"
     env_file:
       - .env
+    environment:
+      - DEV=${DEV-}
     volumes:
       - ./backend/src:/var/backend/src:rw
       - ./backend/tools:/var/backend/tools:ro
@@ -43,8 +45,11 @@ services:
     develop:
       watch:
         - action: rebuild
+          path: backend/Dockerfile
+        - action: rebuild
           path: backend/src/pyproject.toml
-
+        - action: rebuild
+          path: backend/tools/
 
   # nextjs:
   #   build:


### PR DESCRIPTION
Subject: Bug fix: docker compose failed to build

Fixes:
 - Docker compose watch rule to make it more convenient to use
 - Dockerfile fails at install and at sync because of edge case (when uv.lock, and PATH does not exist)
 - Fix stripping binary path
 - Fix permissions for link file, and .
 
Added:
 - setup.sh (required by fix).
 - docker compose DEV mode for differentiating dev and non-dev container (required by fix).